### PR TITLE
Fix of non-existing encode_tvc function mentions

### DIFF
--- a/docs/reference/types-and-methods/mod_abi.md
+++ b/docs/reference/types-and-methods/mod_abi.md
@@ -24,7 +24,7 @@ Provides message encoding and decoding according to the ABI specification.
 
 [update_initial_data](mod\_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key. This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
 
-[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `boc.encode_external_in_message` function afterwards.
 
 [decode_initial_data](mod\_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
 
@@ -641,7 +641,7 @@ NOTE: Sync version is available only for `lib-node` binding.
 
 ## encode_initial_data
 
-Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `boc.encode_external_in_message` function afterwards.
 
 This function is analogue of `tvm.buildDataInit` function in Solidity.
 

--- a/docs/reference/types-and-methods/modules.md
+++ b/docs/reference/types-and-methods/modules.md
@@ -149,7 +149,7 @@ Where:
 
 [update_initial_data](mod\_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key. This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
 
-[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `boc.encode_external_in_message` function afterwards.
 
 [decode_initial_data](mod\_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
 

--- a/ton_client/src/abi/init_data.rs
+++ b/ton_client/src/abi/init_data.rs
@@ -124,7 +124,7 @@ pub struct ResultOfEncodeInitialData {
 }
 
 /// Encodes initial account data with initial values for the contract's static variables and owner's
-/// public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+/// public key into a data BOC that can be passed to `boc.encode_external_in_message` function afterwards.
 ///
 /// This function is analogue of `tvm.buildDataInit` function in Solidity.
 #[api_function]


### PR DESCRIPTION
Fixes mentions of old encode_tvc mentions in docs and `init_data.rs`. No other changes.