### PR TITLE
v1.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.48.0]
+
+### New
+
+- Updated project dependencies
+- Supported `abi::types::TokenValueToStackItem` and `abi::types::StackItemToJson` structures for conversions.
+- Supported `crypto::ton_crc16_from_raw_data`. 
+- Fixed `ever_client::boc::get_salt_and_ver` function. 
+
 ## [1.47.0] – 2024-07-12
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "api_derive"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "api_info",
  "proc-macro2",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "api_derive",
  "api_info",
@@ -162,9 +162,9 @@ checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "ascii"
@@ -178,7 +178,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c98233c6673d8601ab23e77eb38f999c51100d46c5703b17288c57fddf3a1ffe"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "doc-comment",
  "predicates 2.1.5",
  "predicates-core",
@@ -194,7 +194,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -314,9 +314,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blst"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dc83a094a71d43eeadd254b1ec2d24cb6a0bb6cadce00df51f0db594711a32"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",
@@ -333,6 +333,15 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -355,19 +364,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -482,15 +490,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -588,7 +596,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -767,8 +775,8 @@ dependencies = [
 
 [[package]]
 name = "ever-struct"
-version = "1.1.2"
-source = "git+https://github.com/everx-labs/ever-struct.git?tag=1.1.2#0a601fcaee0cf768dc1c967e4c77970157c5b861"
+version = "1.1.12"
+source = "git+https://github.com/everx-labs/ever-struct.git?tag=1.1.12#8adb33ae080b5eee5849a8c5949c305a7831f7c6"
 dependencies = [
  "anyhow",
  "ever_block",
@@ -777,8 +785,8 @@ dependencies = [
 
 [[package]]
 name = "ever_abi"
-version = "2.6.2"
-source = "git+https://github.com/everx-labs/ever-abi.git?tag=2.6.2#cd158482598245e075443bc7ea53c69c3f8605db"
+version = "2.7.2"
+source = "git+https://github.com/everx-labs/ever-abi.git?tag=2.7.2#70f946130a68db322fa7fe735c77e5998c4fefb4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -795,8 +803,8 @@ dependencies = [
 
 [[package]]
 name = "ever_block"
-version = "1.11.1"
-source = "git+https://github.com/everx-labs/ever-block.git?tag=1.11.1#d347b63f269fc4ff89cee586f5f4800df69fcb10"
+version = "1.11.11"
+source = "git+https://github.com/everx-labs/ever-block.git?tag=1.11.11#5d617e2f0a8f7ec2b3e0aab9167280260a5ad7f2"
 dependencies = [
  "aes-ctr",
  "anyhow",
@@ -825,8 +833,8 @@ dependencies = [
 
 [[package]]
 name = "ever_block_json"
-version = "0.9.4"
-source = "git+https://github.com/everx-labs/ever-block-json.git?tag=0.9.4#07da7add859dd0ca78563b32dd970224f28d597a"
+version = "0.9.18"
+source = "git+https://github.com/everx-labs/ever-block-json.git?tag=0.9.18#49dab7f222db9026a154a4c200fc2ace14f3911f"
 dependencies = [
  "anyhow",
  "ever_block",
@@ -845,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "ever_client"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -912,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "ever_client_processing"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "api_derive",
  "api_info",
@@ -930,8 +938,8 @@ dependencies = [
 
 [[package]]
 name = "ever_executor"
-version = "1.18.2"
-source = "git+https://github.com/everx-labs/ever-executor.git?tag=1.18.2#0f32b284785b0f00a1438bb0263e04fb5b396359"
+version = "1.18.12"
+source = "git+https://github.com/everx-labs/ever-executor.git?tag=1.18.12#77e5e140aaba4a111e0285792be65f6143f6bf0c"
 dependencies = [
  "anyhow",
  "ever_block",
@@ -943,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "ever_sdk"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "api_derive",
@@ -966,8 +974,8 @@ dependencies = [
 
 [[package]]
 name = "ever_vm"
-version = "2.2.2"
-source = "git+https://github.com/everx-labs/ever-vm.git?tag=2.2.2#e7b6e292deb69379693c37f26754b2d70cde4fbf"
+version = "2.2.12"
+source = "git+https://github.com/everx-labs/ever-vm.git?tag=2.2.12#ebd07bab74de939cfc71b1f56aa314cb58695318"
 dependencies = [
  "anyhow",
  "diffy",
@@ -984,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "evercli"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "api_info",
  "assert_cmd",
@@ -1112,7 +1120,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1451,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1482,9 +1490,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1680,7 +1688,7 @@ checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1700,13 +1708,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1790,7 +1799,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1845,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1866,9 +1875,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
@@ -1887,7 +1896,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1907,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -2011,7 +2020,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2061,9 +2070,9 @@ checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "powerfmt"
@@ -2073,9 +2082,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -2103,15 +2115,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2234,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2254,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2516,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
@@ -2529,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2545,9 +2557,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
@@ -2564,23 +2576,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
  "indexmap",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2593,7 +2606,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2667,11 +2680,11 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 dependencies = [
- "bstr",
+ "bstr 1.10.0",
 ]
 
 [[package]]
@@ -2749,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2787,14 +2800,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2805,29 +2819,29 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "thread-id"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
 dependencies = [
  "libc",
  "winapi",
@@ -2909,30 +2923,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3011,8 +3024,8 @@ dependencies = [
 
 [[package]]
 name = "ton_api"
-version = "0.4.2"
-source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.4.2#60920237cadad90f4d123db741b0c765fc030a84"
+version = "0.4.15"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.4.15#64b38c6b79a0ef7177d7fd0562ef7552697ce586"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3032,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "ton_tl_codegen"
 version = "0.1.0"
-source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.4.2#60920237cadad90f4d123db741b0c765fc030a84"
+source = "git+https://github.com/everx-labs/ever-tl.git?tag=0.4.15#64b38c6b79a0ef7177d7fd0562ef7552697ce586"
 dependencies = [
  "crc 1.8.1",
  "pom",
@@ -3222,9 +3235,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -3283,7 +3296,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
@@ -3317,7 +3330,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3408,6 +3421,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3567,6 +3589,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -3578,7 +3601,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3598,7 +3621,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3622,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,5 @@
 [workspace]
 exclude = [ 'examples/rust' ]
-members = [
-    'ever_sdk',
-    'ever_client',
-    'ever_client_processing',
-    'evercli',
-    'api/test',
-    'tools/update_trusted_blocks'
-]
+members = [ 'ever_sdk', 'ever_client', 'ever_client_processing', 'evercli', 'api/test', 'tools/update_trusted_blocks' ]
+
+

--- a/api/derive/Cargo.toml
+++ b/api/derive/Cargo.toml
@@ -2,14 +2,15 @@
 authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
 edition = '2018'
 name = 'api_derive'
-version = '1.47.0'
+version = '1.48.0'
 
 [dependencies]
+proc-macro2 = '1.0.52'
 quote = '1.0.26'
 serde_json = '1.0.57'
-api_info = { path = '../info' }
 syn = { features = [ 'full' ], version = '1.0.109' }
-proc-macro2 = "1.0.52"
+api_info = { path = '../info' }
 
 [lib]
 proc-macro = true
+

--- a/api/info/Cargo.toml
+++ b/api/info/Cargo.toml
@@ -2,7 +2,7 @@
 authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
 edition = '2018'
 name = 'api_info'
-version = '1.47.0'
+version = '1.48.0'
 
 [dependencies]
 serde = '1.0.115'
@@ -11,3 +11,4 @@ serde_json = '1.0.57'
 
 [lib]
 name = 'api_info'
+

--- a/api/test/Cargo.toml
+++ b/api/test/Cargo.toml
@@ -2,7 +2,7 @@
 authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
 edition = '2018'
 name = 'api_test'
-version = '1.47.0'
+version = '1.48.0'
 
 [dependencies]
 serde = '1.0.115'
@@ -13,3 +13,4 @@ api_info = { path = '../info' }
 
 [lib]
 name = 'api_test'
+

--- a/ever_client/Cargo.toml
+++ b/ever_client/Cargo.toml
@@ -1,38 +1,14 @@
 [package]
-name = 'ever_client'
-version = '1.47.0'
 authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
+build = 'build.rs'
 edition = '2018'
 license = 'Apache-2.0'
-build = 'build.rs'
-
-[lib]
 name = 'ever_client'
-crate-type = [ 'cdylib', 'rlib', 'staticlib' ]
-
-[build-dependencies]
-serde = '1.0.117'
-serde_derive = '1.0.117'
-serde_json = '1.0.59'
+version = '1.48.0'
 
 [dependencies]
-api_derive = { path = '../api/derive' }
-api_info = { path = '../api/info' }
-ever_sdk = { default-features = false, path = '../ever_sdk' }
-ever_client_processing = { default-features = false, path = '../ever_client_processing' }
-
-ever_abi = { git = 'https://github.com/everx-labs/ever-abi.git',  tag = '2.6.2' }
-ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.1' }
-ever_block_json = { git = 'https://github.com/everx-labs/ever-block-json.git', tag = '0.9.4' }
-ever_executor = { features = ['signature_with_id'], git = 'https://github.com/everx-labs/ever-executor.git', tag = '1.18.2' }
-ever_vm = { features = ['signature_with_id', 'signature_no_check'], git = 'https://github.com/everx-labs/ever-vm.git', tag = '2.2.2' }
-ever-struct = { git = 'https://github.com/everx-labs/ever-struct.git', tag = '1.1.2' }
-
-lockfree = { git = 'https://github.com/everx-labs/lockfree.git', package = 'lockfree' }
-sodalite = { features = [ 'rand' ], git = 'https://github.com/everx-labs/sodalite.git' }
-
-
 aes = '0.7.4'
+anyhow = '1.0'
 async-trait = '0.1.40'
 base58 = '0.1.0'
 base64 = '0.10.0'
@@ -43,11 +19,12 @@ chacha20 = '0.6.0'
 chrono = '0.4.6'
 crc = '3.0'
 ed25519-dalek = '2.0'
-anyhow = '1.0'
-thiserror = '1.0'
 futures = '0.3.4'
 hex = '0.3.2'
 hmac = '0.11.0'
+home = { optional = true, version = '0.5.3' }
+indexed_db_futures = { default-features = false, optional = true, version = '0.2.0' }
+js-sys = { optional = true, version = '0.3.50' }
 lazy_static = '1.1.0'
 libsecp256k1 = '0.6.0'
 log = '0.4.11'
@@ -58,49 +35,40 @@ num-traits = '0.2'
 pbkdf2 = { default-features = false, version = '0.8.0' }
 rand = '0.7.3'
 regex = '1.5.4'
+reqwest = { default-features = false, features = [ 'cookies' ], optional = true, version = '0.11.11' }
 scrypt = { default-features = false, version = '0.7.0' }
 serde = '1.0.91'
 serde_derive = '1.0.91'
 serde_json = '1.0.41'
 serde_repr = '0.1.7'
 sha2 = '0.9.5'
+thiserror = '1.0'
 tiny-bip39 = '0.8.2'
 tokio = { default-features = false, features = [ 'sync' ], version = '1.4' }
 tokio-stream = { default-features = false, version = '0.1' }
-zeroize = { features = [ 'zeroize_derive' ], version = '1.3' }
-
-# optional
-zstd = { default-features = false, optional = true, version = '0.11.0' }
-
-# optional for std
-reqwest = { features = [ 'cookies' ], optional = true, version = '0.11.11', default-features = false }
 tokio-tungstenite = { optional = true, version = '0.17.1' }
-
-# optional for wasm
-indexed_db_futures = { default-features = false, optional = true, version = '0.2.0' }
-js-sys = { optional = true, version = '0.3.50' }
 wasm-bindgen = { optional = true, version = '0.2.73' }
 wasm-bindgen-futures = { optional = true, version = '0.4.15' }
+web-sys = { features = [ 'ErrorEvent', 'FileReader', 'Headers', 'MessageEvent', 'ProgressEvent', 'Request', 'RequestInit', 'Response', 'Window', 'WebSocket' ], optional = true, version = '0.3.42' }
+zeroize = { features = [ 'zeroize_derive' ], version = '1.3' }
+zstd = { default-features = false, optional = true, version = '0.11.0' }
+api_derive = { path = '../api/derive' }
+api_info = { path = '../api/info' }
+ever-struct = { git = 'https://github.com/everx-labs/ever-struct.git', tag = '1.1.12' }
+ever_abi = { git = 'https://github.com/everx-labs/ever-abi.git', tag = '2.7.2' }
+ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.11' }
+ever_block_json = { git = 'https://github.com/everx-labs/ever-block-json.git', tag = '0.9.18' }
+ever_client_processing = { default-features = false, path = '../ever_client_processing' }
+ever_executor = { features = [ 'signature_with_id' ], git = 'https://github.com/everx-labs/ever-executor.git', tag = '1.18.12' }
+ever_sdk = { default-features = false, path = '../ever_sdk' }
+ever_vm = { features = [ 'signature_with_id', 'signature_no_check' ], git = 'https://github.com/everx-labs/ever-vm.git', tag = '2.2.12' }
+lockfree = { git = 'https://github.com/everx-labs/lockfree.git', package = 'lockfree' }
+sodalite = { features = [ 'rand' ], git = 'https://github.com/everx-labs/sodalite.git' }
 
-[dependencies.home]
-version = '0.5.3'
-optional = true
-
-[dependencies.web-sys]
-version = '0.3.42'
-optional = true
-features = [
-    'ErrorEvent',
-    'FileReader',
-    'Headers',
-    'MessageEvent',
-    'ProgressEvent',
-    'Request',
-    'RequestInit',
-    'Response',
-    'Window',
-    'WebSocket'
-]
+[build-dependencies]
+serde = '1.0.117'
+serde_derive = '1.0.117'
+serde_json = '1.0.59'
 
 [dev-dependencies]
 dirs = '2.0.2'
@@ -108,37 +76,19 @@ graphql-parser = '0.3.0'
 log4rs = '1.1'
 pretty_assertions = '1.2'
 
-
 [features]
 default = [ 'std', 'native-tls' ]
 include-zstd = [ 'ever_block/gosh', 'ever_vm/gosh' ]
-std = [
-    'tokio/rt-multi-thread',
-    'tokio/macros',
-    'tokio/time',
-    'tokio/net',
-    'tokio/fs',
-    'home',
-    'include-zstd',
-    'zstd'
-]
 native-tls = [ 'reqwest/default', 'tokio-tungstenite/native-tls' ]
 native-tls-vendored = [ 'reqwest/native-tls-vendored', 'tokio-tungstenite/native-tls-vendored' ]
 rustls-tls-native-roots = [ 'reqwest/rustls-tls-native-roots', 'tokio-tungstenite/rustls-tls-native-roots' ]
 rustls-tls-webpki-roots = [ 'reqwest/rustls-tls-webpki-roots', 'tokio-tungstenite/rustls-tls-webpki-roots' ]
-wasm = [
-    'wasm-base',
-    'include-zstd',
-    'zstd',
-    'zstd/thin',
-    'zstd/wasm'
-]
-wasm-base = [
-    'chrono/wasmbind',
-    'indexed_db_futures',
-    'js-sys',
-    'rand/wasm-bindgen',
-    'wasm-bindgen',
-    'wasm-bindgen-futures',
-    'web-sys'
-]
+std = [ 'tokio/rt-multi-thread', 'tokio/macros', 'tokio/time', 'tokio/net', 'tokio/fs', 'home', 'include-zstd', 'zstd' ]
+wasm = [ 'wasm-base', 'include-zstd', 'zstd', 'zstd/thin', 'zstd/wasm' ]
+wasm-base = [ 'chrono/wasmbind', 'indexed_db_futures', 'js-sys', 'rand/wasm-bindgen', 'wasm-bindgen', 'wasm-bindgen-futures', 'web-sys' ]
+
+[lib]
+crate-type = [ 'cdylib', 'rlib', 'staticlib' ]
+name = 'ever_client'
+
+

--- a/ever_client/src/abi/mod.rs
+++ b/ever_client/src/abi/mod.rs
@@ -60,6 +60,7 @@ pub use init_data::{
 pub use signing::Signer;
 pub use types::{
     Abi, AbiContract, AbiData, AbiEvent, AbiFunction, AbiHandle, AbiParam, FunctionHeader,
+    TokenValueToStackItem, StackItemToJson
 };
 
 pub fn default_workchain() -> i32 {

--- a/ever_client/src/boc/state_init.rs
+++ b/ever_client/src/boc/state_init.rs
@@ -34,8 +34,7 @@ const OLD_SOL_SELECTOR_DATA: &[u8] = &[
     0x30, 0xf4, 0xa1,
 ];
 const NEW_SELECTOR_DATA: &[u8] = &[
-    0x8a, 0xed, 0x53, 0x20, 0xe3, 0x03, 0x20, 0xc0, 0xff, 0xe3, 0x02, 0x20, 0xc0, 0xfe, 0xe3, 0x02,
-    0xf2, 0x0b,
+    0x8a, 0xed, 0x53, 0x20, 0xe3, 0x03, 0x20, 0xc0, 0xff, 0xe3, 0x02
 ];
 const MYCODE_SELECTOR_DATA: &[u8] = &[0x8A, 0xDB, 0x35];
 
@@ -101,7 +100,7 @@ pub fn get_salt_and_ver(code: Cell) -> ClientResult<(Option<Cell>, Option<Cell>)
     match code.data() {
         OLD_CPP_SELECTOR_DATA => get_old_selector_salt(&code).map(|salt| (salt, None)),
         OLD_SOL_SELECTOR_DATA => Ok((None, None)),
-        NEW_SELECTOR_DATA => {
+        code_data if code_data.starts_with(NEW_SELECTOR_DATA) => {
             get_new_selector_salt_and_ver(&code).map(|(salt, ver)| (salt, Some(ver)))
         }
         MYCODE_SELECTOR_DATA => {
@@ -233,7 +232,7 @@ pub fn set_code_salt(
 
     let code = match code.data() {
         OLD_CPP_SELECTOR_DATA => set_old_selector_salt(code, salt),
-        NEW_SELECTOR_DATA => set_new_selector_salt(code, salt),
+        code_data if code_data.starts_with(NEW_SELECTOR_DATA) => set_new_selector_salt(code, salt),
         MYCODE_SELECTOR_DATA => set_mycode_selector_salt(code, salt),
         OLD_SOL_SELECTOR_DATA => Err(Error::invalid_boc(
             "the contract doesn't support salt adding",

--- a/ever_client/src/client/storage.rs
+++ b/ever_client/src/client/storage.rs
@@ -21,6 +21,7 @@ pub trait KeyValueStorage: Send + Sync {
     async fn put_str(&self, key: &str, value: &str) -> ClientResult<()>;
 
     /// Remove value by a given key
+    #[allow(dead_code)]
     async fn remove(&self, key: &str) -> ClientResult<()>;
 }
 

--- a/ever_client/src/crypto/hdkey.rs
+++ b/ever_client/src/crypto/hdkey.rs
@@ -223,27 +223,7 @@ impl HDPrivateKey {
     }
 
     fn map_secp_error(error: libsecp256k1::Error) -> ClientError {
-        match error {
-            libsecp256k1::Error::InvalidSignature => {
-                crypto::Error::bip32_invalid_key("InvalidSignature")
-            }
-            libsecp256k1::Error::InvalidPublicKey => {
-                crypto::Error::bip32_invalid_key("InvalidPublicKey")
-            }
-            libsecp256k1::Error::InvalidSecretKey => {
-                crypto::Error::bip32_invalid_key("InvalidSecretKey")
-            }
-            libsecp256k1::Error::InvalidRecoveryId => {
-                crypto::Error::bip32_invalid_key("InvalidRecoveryId")
-            }
-            libsecp256k1::Error::InvalidMessage => crypto::Error::bip32_invalid_key("InvalidMessage"),
-            libsecp256k1::Error::InvalidInputLength => {
-                crypto::Error::bip32_invalid_key("InvalidInputLength")
-            }
-            libsecp256k1::Error::TweakOutOfRange => {
-                crypto::Error::bip32_invalid_key("TweakOutOfRange")
-            }
-        }
+        crypto::Error::bip32_invalid_key(format!("{}", error))
     }
 
     pub(crate) fn derive(

--- a/ever_client/src/crypto/math.rs
+++ b/ever_client/src/crypto/math.rs
@@ -219,6 +219,13 @@ pub fn ton_crc16(
     })
 }
 
+#[api_function]
+pub fn ton_crc16_from_raw_data(
+    raw_data: Vec<u8>
+) -> u16 {
+    crypto::internal::ton_crc16(&raw_data)
+}
+
 //--------------------------------------------------------------------------- generate_random_bytes
 
 #[derive(Serialize, Deserialize, ApiType, Default)]

--- a/ever_client/src/crypto/mnemonic.rs
+++ b/ever_client/src/crypto/mnemonic.rs
@@ -272,7 +272,9 @@ pub trait CryptoMnemonic {
     ) -> ClientResult<KeyPair>;
     fn phrase_from_entropy(&self, entropy: &[u8]) -> ClientResult<String>;
     fn is_phrase_valid(&self, phrase: &String) -> ClientResult<bool>;
+    #[allow(dead_code)]
     fn seed_from_phrase_and_salt(&self, phrase: &String, salt: &String) -> ClientResult<String>;
+    #[allow(dead_code)]
     fn entropy_from_phrase(&self, phrase: &String) -> ClientResult<String>;
 }
 

--- a/ever_client/src/crypto/mod.rs
+++ b/ever_client/src/crypto/mod.rs
@@ -71,7 +71,7 @@ pub use crate::crypto::keys::{
     ResultOfConvertPublicKeyToTonSafeFormat, ResultOfSign, ResultOfVerifySignature,
 };
 pub use crate::crypto::math::{
-    factorize, generate_random_bytes, modular_power, ton_crc16, ParamsOfFactorize,
+    factorize, generate_random_bytes, modular_power, ton_crc16, ton_crc16_from_raw_data, ParamsOfFactorize,
     ParamsOfGenerateRandomBytes, ParamsOfModularPower, ParamsOfTonCrc16, ResultOfFactorize,
     ResultOfGenerateRandomBytes, ResultOfModularPower, ResultOfTonCrc16,
 };

--- a/ever_client/src/crypto/tests.rs
+++ b/ever_client/src/crypto/tests.rs
@@ -455,7 +455,7 @@ fn mnemonic() {
         .unwrap();
     assert_eq!(result.words.split(" ").count(), 2048);
 
-    for dictionary in 1..9 {
+    for dictionary in 0..9 {
         for word_count in &[12u8, 15, 18, 21, 24] {
             let result: ResultOfMnemonicFromRandom = client
                 .request(
@@ -485,7 +485,7 @@ fn mnemonic() {
         "abandon math mimic master filter design carbon crystal rookie group knife young"
     );
 
-    for dictionary in 1..9 {
+    for dictionary in 0..9 {
         for word_count in &[12u8, 15, 18, 21, 24] {
             let result: ResultOfMnemonicFromRandom = client
                 .request(

--- a/ever_client/src/tvm/call_tvm.rs
+++ b/ever_client/src/tvm/call_tvm.rs
@@ -25,6 +25,35 @@ use ever_vm::{
     stack::{integer::IntegerData, savelist::SaveList, Stack, StackItem},
 };
 
+use ever_vm::executor::EngineTraceInfo;
+use ever_vm::executor::EngineTraceInfoType;
+
+fn trace_callback(_engine: &Engine, info: &EngineTraceInfo, extended: bool) {
+    if info.info_type == EngineTraceInfoType::Dump {
+        println!("{}", info.cmd_str);
+        return
+    }
+    println!("{}: {}",
+             info.step,
+             info.cmd_str
+    );
+    if extended {
+        println!("{} {}",
+             info.cmd_code.remaining_bits(),
+             info.cmd_code.to_hex_string()
+        );
+    }
+    println!("\nGas: {} ({})",
+             info.gas_used,
+             info.gas_cmd
+    );
+    println!("\n--- Stack trace ------------------------");
+    for item in info.stack.iter() {
+        println!("{}", item);
+    }
+    println!("----------------------------------------\n");
+}
+
 pub(crate) fn call_tvm(
     account: &mut Account,
     options: ResolvedExecutionOptions,
@@ -75,6 +104,7 @@ pub(crate) fn call_tvm(
 
     engine.set_signature_id(options.signature_id);
     engine.modify_behavior(options.behavior_modifiers);
+    // engine.set_trace_callback(move |engine, info| { trace_callback(engine, info, true); });
 
     match engine.execute() {
         Err(err) => {
@@ -154,6 +184,27 @@ pub(crate) fn call_tvm_msg(
 
     msgs.reverse();
     Ok(msgs)
+}
+
+// For solidity
+pub(crate) fn call_tvm_msg_getter(
+    account: &mut Account,
+    options: ResolvedExecutionOptions,
+    stack_items: Vec<StackItem>
+) -> ClientResult<Vec<StackItem>> {
+
+    let mut stack = Stack::new();
+    for x in stack_items {
+        stack.push(x);
+    }
+
+    let engine = call_tvm(account, options, stack)?;
+
+    let mut items = vec![];
+    for item in engine.stack().iter() {
+        items.push(item.clone());
+    }
+    Ok(items)
 }
 
 fn build_contract_info(

--- a/ever_client/src/tvm/call_tvm.rs
+++ b/ever_client/src/tvm/call_tvm.rs
@@ -25,34 +25,35 @@ use ever_vm::{
     stack::{integer::IntegerData, savelist::SaveList, Stack, StackItem},
 };
 
-use ever_vm::executor::EngineTraceInfo;
-use ever_vm::executor::EngineTraceInfoType;
 
-fn trace_callback(_engine: &Engine, info: &EngineTraceInfo, extended: bool) {
-    if info.info_type == EngineTraceInfoType::Dump {
-        println!("{}", info.cmd_str);
-        return
-    }
-    println!("{}: {}",
-             info.step,
-             info.cmd_str
-    );
-    if extended {
-        println!("{} {}",
-             info.cmd_code.remaining_bits(),
-             info.cmd_code.to_hex_string()
-        );
-    }
-    println!("\nGas: {} ({})",
-             info.gas_used,
-             info.gas_cmd
-    );
-    println!("\n--- Stack trace ------------------------");
-    for item in info.stack.iter() {
-        println!("{}", item);
-    }
-    println!("----------------------------------------\n");
-}
+// for debugging getters
+// use ever_vm::executor::EngineTraceInfo;
+// use ever_vm::executor::EngineTraceInfoType;
+// fn trace_callback(_engine: &Engine, info: &EngineTraceInfo, extended: bool) {
+//     if info.info_type == EngineTraceInfoType::Dump {
+//         println!("{}", info.cmd_str);
+//         return
+//     }
+//     println!("{}: {}",
+//              info.step,
+//              info.cmd_str
+//     );
+//     if extended {
+//         println!("{} {}",
+//              info.cmd_code.remaining_bits(),
+//              info.cmd_code.to_hex_string()
+//         );
+//     }
+//     println!("\nGas: {} ({})",
+//              info.gas_used,
+//              info.gas_cmd
+//     );
+//     println!("\n--- Stack trace ------------------------");
+//     for item in info.stack.iter() {
+//         println!("{}", item);
+//     }
+//     println!("----------------------------------------\n");
+// }
 
 pub(crate) fn call_tvm(
     account: &mut Account,

--- a/ever_client/src/tvm/mod.rs
+++ b/ever_client/src/tvm/mod.rs
@@ -26,7 +26,7 @@ mod tests;
 pub use errors::{Error, ErrorCode, StdContractError};
 pub use run_get::{run_get, ParamsOfRunGet, ResultOfRunGet};
 pub use run_message::{
-    run_executor, run_tvm, AccountForExecutor, ParamsOfRunExecutor, ParamsOfRunTvm,
+    run_executor, run_tvm, run_solidity_getter, AccountForExecutor, ParamsOfRunExecutor, ParamsOfRunTvm,
     ResultOfRunExecutor, ResultOfRunTvm,
 };
 pub(crate) use run_message::run_executor_internal;

--- a/ever_client_processing/Cargo.toml
+++ b/ever_client_processing/Cargo.toml
@@ -1,21 +1,13 @@
 [package]
-name = 'ever_client_processing'
-version = '1.47.0'
 authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
 edition = '2018'
 license = 'Apache-2.0'
-
-[lib]
 name = 'ever_client_processing'
-crate-type = [ 'cdylib', 'rlib', 'staticlib' ]
+version = '1.48.0'
 
 [dependencies]
-ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.1' }
-
-api_derive = { path = '../api/derive' }
-api_info = { path = '../api/info' }
-
 async-trait = '0.1.40'
+base64 = '0.21.0'
 futures = '0.3.4'
 log = '0.4.11'
 serde = '1.0.91'
@@ -23,7 +15,14 @@ serde_derive = '1.0.91'
 serde_json = '1.0.41'
 serde_repr = '0.1.7'
 tokio = { default-features = false, features = [ 'sync' ], version = '1.4' }
-base64 = "0.21.0"
+api_derive = { path = '../api/derive' }
+api_info = { path = '../api/info' }
+ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.11' }
 
 [dev-dependencies]
 tokio = { default-features = false, features = [ 'sync', 'rt-multi-thread', 'macros', 'time', 'net', 'fs' ], version = '1.4' }
+
+[lib]
+crate-type = [ 'cdylib', 'rlib', 'staticlib' ]
+name = 'ever_client_processing'
+

--- a/ever_sdk/Cargo.toml
+++ b/ever_sdk/Cargo.toml
@@ -1,27 +1,26 @@
 [package]
-name = 'ever_sdk'
-version = '1.47.0'
+authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
 edition = '2018'
 license = 'Apache-2.0'
-authors = [ 'EverX Labs Ltd <support@everx.dev>' ]
+name = 'ever_sdk'
+version = '1.48.0'
 
 [dependencies]
-ever_abi = { git = 'https://github.com/everx-labs/ever-abi.git',  tag = '2.6.2' }
-ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.1' }
-
-api_info = { path = '../api/info' }
-api_derive = { path = '../api/derive' }
-
-num-bigint = '0.4'
-sha2 = '0.9'
-serde_json = '1.0.41'
-serde = '1.0.91'
-serde_derive = '1.0.91'
-hex = '0.3.2'
-lazy_static = '1.1.0'
+anyhow = '1.0'
 base64 = '0.10.0'
 chrono = '0.4.9'
-anyhow = '1.0'
-thiserror = '1.0'
-num-traits = '0.2'
+hex = '0.3.2'
+lazy_static = '1.1.0'
 log = '0.4.11'
+num-bigint = '0.4'
+num-traits = '0.2'
+serde = '1.0.91'
+serde_derive = '1.0.91'
+serde_json = '1.0.41'
+sha2 = '0.9'
+thiserror = '1.0'
+api_derive = { path = '../api/derive' }
+api_info = { path = '../api/info' }
+ever_abi = { git = 'https://github.com/everx-labs/ever-abi.git', tag = '2.7.2' }
+ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.11' }
+

--- a/evercli/Cargo.toml
+++ b/evercli/Cargo.toml
@@ -9,7 +9,7 @@ license = 'Apache-2.0'
 name = 'evercli'
 readme = 'README.md'
 repository = 'https://github.com/everx-labs/ever-sdk'
-version = '1.47.0'
+version = '1.48.0'
 
 [dependencies]
 base64 = '0.13.0'
@@ -25,3 +25,4 @@ ever_client = { path = '../ever_client' }
 [dev-dependencies]
 assert_cmd = '1.0.1'
 predicates = '1.0.5'
+

--- a/tools/api.json
+++ b/tools/api.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.47.0",
+  "version": "1.48.0",
   "modules": [
     {
       "name": "client",

--- a/tools/update_trusted_blocks/Cargo.toml
+++ b/tools/update_trusted_blocks/Cargo.toml
@@ -4,11 +4,12 @@ name = 'update_trusted_blocks'
 version = '0.1.0'
 
 [dependencies]
-bincode = '1.3.3'
 anyhow = '1.0'
+bincode = '1.3.3'
 serde = '1.0.130'
 serde_derive = '1.0.130'
 serde_json = '1.0.68'
 tokio = { default-features = false, features = [ 'sync', 'fs' ], version = '1' }
+ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.11' }
 ever_client = { path = '../../ever_client' }
-ever_block = { git = 'https://github.com/everx-labs/ever-block.git', tag = '1.11.1' }
+


### PR DESCRIPTION
- Updated project dependencies
- Supported `abi::types::TokenValueToStackItem` and `abi::types::StackItemToJson` structures for conversions.
- Supported `crypto::ton_crc16_from_raw_data`. 
- Fixed `ever_client::boc::get_salt_and_ver` function. 